### PR TITLE
add netcdf files to the list of considered files

### DIFF
--- a/tools/scripts/lib.r
+++ b/tools/scripts/lib.r
@@ -322,7 +322,7 @@ getSampleMetadata <- function(xdata=NULL, sampleMetadataOutput="sampleMetadata.t
 checkFilesCompatibilityWithXcms <- function(directory) {
     cat("Checking files filenames compatibilities with xmcs...\n")
     # WHAT XCMS WILL FIND
-    filepattern <- c("[Cc][Dd][Ff]", "[Nn][Cc]", "([Mm][Zz])?[Xx][Mm][Ll]","[Mm][Zz][Dd][Aa][Tt][Aa]", "[Mm][Zz][Mm][Ll]")
+    filepattern <- c("([Nn][Ee][Tt])?[Cc][Dd][Ff]", "[Nn][Cc]", "([Mm][Zz])?[Xx][Mm][Ll]","[Mm][Zz][Dd][Aa][Tt][Aa]", "[Mm][Zz][Mm][Ll]")
     filepattern <- paste(paste("\\.", filepattern, "$", sep=""),collapse="|")
     info <- file.info(directory)
     listed <- list.files(directory[info$isdir], pattern=filepattern, recursive=TRUE, full.names=TRUE)
@@ -348,7 +348,7 @@ checkFilesCompatibilityWithXcms <- function(directory) {
 #This function list the compatible files within the directory as xcms did
 #@author Gildas Le Corguille lecorguille@sb-roscoff.fr ABiMS TEAM
 getMSFiles <- function (directory) {
-    filepattern <- c("[Cc][Dd][Ff]", "[Nn][Cc]", "([Mm][Zz])?[Xx][Mm][Ll]","[Mm][Zz][Dd][Aa][Tt][Aa]", "[Mm][Zz][Mm][Ll]")
+    filepattern <- c("([Nn][Ee][Tt])?[Cc][Dd][Ff]", "[Nn][Cc]", "([Mm][Zz])?[Xx][Mm][Ll]","[Mm][Zz][Dd][Aa][Tt][Aa]", "[Mm][Zz][Mm][Ll]")
     filepattern <- paste(paste("\\.", filepattern, "$", sep=""),collapse="|")
     info <- file.info(directory)
     listed <- list.files(directory[info$isdir], pattern=filepattern,recursive=TRUE, full.names=TRUE)


### PR DESCRIPTION
The galaxy wrapper accepts netcdf, but the R scripts don't. 

Still, with this change I'm unable to process the file that I got from our users:

```
			Load Raw Data
[1] "vobjtovarid4: error #F: I could not find the requsted var (or dimvar) in the file!"
[1] "var (or dimvar) name: instrument_name"
[1] "file name: /gpfs1/work/songalax/galaxy/database/jobs_directory/026/26742/working/FAME_1_10_1.netcdf"
Error in vobjtovarid4(nc, varid, verbose = verbose, allowdimvar = TRUE) : 
  Variable not found
Calls: readMSData ... netCDFVarText -> as.vector -> ncvar_get -> vobjtovarid4
Execution halted
```

The file might be corrupted... could you help me to debug this? I'm completely new to this format...