### PR TITLE
camera - annotate - fix zip export

### DIFF
--- a/tools/camera_annotate/README.rst
+++ b/tools/camera_annotate/README.rst
@@ -2,6 +2,10 @@
 Changelog/News
 --------------
 
+**Version 2.2.5+camera1.42.0+galaxy1 - 09/03/2020**
+
+- BUGFIX: Fix the zip export of the pictures (eic and boxplot)
+
 **Version 2.2.5+camera1.42.0 - 13/02/2020**
 
 - UPGRADE: upgrade the xcms version from 3.0.0 to 1.42.0 (see CAMERA News_)

--- a/tools/camera_annotate/abims_CAMERA_annotateDiffreport.xml
+++ b/tools/camera_annotate/abims_CAMERA_annotateDiffreport.xml
@@ -185,13 +185,13 @@
         </data>
 
         <data name="output_diffreport_eic_zip" format="zip" label="${image.name[:-6]}.annotateDiffreport_eic.zip" from_work_dir="eic.zip" >
-            <filter>diffreport['options']['option'] == 'show' and diffreport['options']['png2'] == 'zip'</filter>
+            <filter>diffreport['options']['option'] == 'show' and diffreport['options']['eicmax'] > 0 and diffreport['options']['png2'] == 'zip'</filter>
         </data>
         <data name="output_diffreport_box_zip" format="zip" label="${image.name[:-6]}.annotateDiffreport_box.zip" from_work_dir="box.zip" >
-            <filter>diffreport['options']['option'] == 'show' and diffreport['options']['png2'] == 'zip'</filter>
+            <filter>diffreport['options']['option'] == 'show' and diffreport['options']['eicmax'] > 0 and diffreport['options']['png2'] == 'zip'</filter>
         </data>
         <collection name="output_diffreport_picture_pdf" type="list" label="${image.name[:-6]}.annotateDiffreport.pdf">
-            <filter>diffreport['options']['option'] == 'show' and diffreport['options']['png2'] == 'pdf'</filter>
+            <filter>diffreport['options']['option'] == 'show' and diffreport['options']['eicmax'] > 0 and diffreport['options']['png2'] == 'pdf'</filter>
             <discover_datasets pattern="__designation_and_ext__" directory="pdf" format="pdf" />
         </collection>
 

--- a/tools/camera_annotate/abims_CAMERA_annotateDiffreport.xml
+++ b/tools/camera_annotate/abims_CAMERA_annotateDiffreport.xml
@@ -1,4 +1,4 @@
-<tool id="abims_CAMERA_annotateDiffreport" name="CAMERA.annotate" version="2.2.5+camera@TOOL_VERSION@+galaxy0">
+<tool id="abims_CAMERA_annotateDiffreport" name="CAMERA.annotate" version="2.2.5+camera@TOOL_VERSION@+galaxy1">
 
     <description>CAMERA annotate function. Returns annotation results (isotope peaks, adducts and fragments) and a diffreport if more than one condition.</description>
 
@@ -435,6 +435,10 @@ Changelog/News
 --------------
 
 .. _News: https://bioconductor.org/packages/release/bioc/news/CAMERA/NEWS
+
+**Version 2.2.5+camera1.42.0+galaxy1 - 09/03/2020**
+
+- BUGFIX: Fix the zip export of the pictures (eic and boxplot)
 
 @HELP_CAMERA_NEWVERSION_1420@
 

--- a/tools/camera_macro/lib.r
+++ b/tools/camera_macro/lib.r
@@ -187,12 +187,12 @@ annotatediff <- function(xset=xset, args=args, variableMetadataOutput="variableM
                     if (args$eicmax != 0) {
                         if (args$png2 == "pdf")
                             diffreport_png2pdf(filebase)
+                        if (args$png2 == "zip")
+                            diffreport_png2zip()
                     }
                 }
             }
         }
-        if (args$png2 == "zip")
-            diffreport_png2zip()
         if (args$tabular2 == "zip")
             diffreport_tabular2zip()
     }


### PR DESCRIPTION
@yguitton This MR  should fix this error
```
Error in zip("eic.zip", dir(pattern = "_eic"), zip = Sys.which("zip")) : 
  'files' must a character vector specifying one or more filepaths
Calls: annotatediff -> diffreport_png2zip -> zip
```

My bad!