### PR TITLE
nmr_preprocessing - ReadFids - add zip datatype

### DIFF
--- a/tools/nmr_preprocessing/ReadFids_xml.xml
+++ b/tools/nmr_preprocessing/ReadFids_xml.xml
@@ -34,7 +34,7 @@
     </command>
 
     <inputs>
-        <param name="fidzipfile" type="data" format="no_unzip.zip" label="Bruker FID file" />
+        <param name="fidzipfile" type="data" format="no_unzip.zip,zip" label="Bruker FID file" />
         <param name="title_line" label="Specify the line in the title file to recover the FID names (usually in pdata/1/title)" type="integer" value="1" size="100" help="Default value is line 1"/>
 
         <param name="subdirectories" label="Presence of subdirectories?" type="select" help="Select 'FALSE' when there is no subdirectories, 'TRUE' if there are subdirectories">


### PR DESCRIPTION
@mtremblayfr 
This will allow `zip` datatype in the meanwhile: https://github.com/galaxyproject/galaxy/issues/9530
Users will have to select zip within the upload interface