### PR TITLE
XCMS minor fixes

### DIFF
--- a/tools/xcms_group/abims_xcms_group.xml
+++ b/tools/xcms_group/abims_xcms_group.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_group" name="xcms groupChromPeaks (group)" version="@TOOL_VERSION@+galaxy0">
+<tool id="abims_xcms_group" name="xcms groupChromPeaks (group)" version="@TOOL_VERSION@+galaxy1">
 
     <description>Perform the correspondence, the grouping of chromatographic peaks within and between samples.</description>
 
@@ -357,7 +357,7 @@ Changelog/News
 
 .. _News: https://bioconductor.org/packages/release/bioc/news/xcms/NEWS
 
-**Version 3.x.x.x - 22/04/2020**
+**Version 3.6.1+galaxy1 - 22/04/2020**
 
 - BUGFIX: sample group colours were not displayed in plots.
 

--- a/tools/xcms_group/abims_xcms_group.xml
+++ b/tools/xcms_group/abims_xcms_group.xml
@@ -357,6 +357,10 @@ Changelog/News
 
 .. _News: https://bioconductor.org/packages/release/bioc/news/xcms/NEWS
 
+**Version 3.x.x.x - 22/04/2020**
+
+- BUGFIX: sample group colours were not displayed in plots.
+
 @HELP_XCMS_NEWVERSION_3610@
 
 @HELP_XCMS_NEWVERSION_3440@

--- a/tools/xcms_macro/lib.r
+++ b/tools/xcms_macro/lib.r
@@ -151,12 +151,14 @@ getPlotChromPeakDensity <- function(xdata, param = NULL, mzdigit=4) {
 
     group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
     names(group_colors) <- unique(xdata$sample_group)
+	col_per_samp <- as.character(xdata$sample_group)
+	for(i in 1:length(group_colors)){col_per_samp[col_per_samp==(names(group_colors)[i])]<-group_colors[i]}
 
     xlim <- c(min(featureDefinitions(xdata)$rtmin), max(featureDefinitions(xdata)$rtmax))
     for (i in 1:nrow(featureDefinitions(xdata))) {
         mzmin = featureDefinitions(xdata)[i,]$mzmin
         mzmax = featureDefinitions(xdata)[i,]$mzmax
-        plotChromPeakDensity(xdata, param = param, mz=c(mzmin,mzmax), col=group_colors, pch=16, xlim=xlim, main=paste(round(mzmin,mzdigit),round(mzmax,mzdigit)))
+        plotChromPeakDensity(xdata, param = param, mz=c(mzmin,mzmax), col=col_per_samp, pch=16, xlim=xlim, main=paste(round(mzmin,mzdigit),round(mzmax,mzdigit)))
         legend("topright", legend=names(group_colors), col=group_colors, cex=0.8, lty=1)
     }
 

--- a/tools/xcms_macro/lib.r
+++ b/tools/xcms_macro/lib.r
@@ -151,8 +151,8 @@ getPlotChromPeakDensity <- function(xdata, param = NULL, mzdigit=4) {
 
     group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
     names(group_colors) <- unique(xdata$sample_group)
-	col_per_samp <- as.character(xdata$sample_group)
-	for(i in 1:length(group_colors)){col_per_samp[col_per_samp==(names(group_colors)[i])]<-group_colors[i]}
+    col_per_samp <- as.character(xdata$sample_group)
+    for(i in 1:length(group_colors)){col_per_samp[col_per_samp==(names(group_colors)[i])]<-group_colors[i]}
 
     xlim <- c(min(featureDefinitions(xdata)$rtmin), max(featureDefinitions(xdata)$rtmax))
     for (i in 1:nrow(featureDefinitions(xdata))) {

--- a/tools/xcms_macro/macros_xcms.xml
+++ b/tools/xcms_macro/macros_xcms.xml
@@ -193,7 +193,7 @@ xset.dataMatrix.tsv : tabular format
             <option value="wMean">intensity weighted mean of the peak's m/z values</option>
             <option value="mean">mean of the peak's m/z values</option>
             <option value="apex">use the m/z value at the peak apex</option>
-            <option value="wMeanApex3">ntensity weighted mean of the m/z value at the peak apex and the m/z values left and right of it</option>
+            <option value="wMeanApex3">intensity weighted mean of the m/z value at the peak apex and the m/z values left and right of it</option>
             <option value="meanApex3">mean of the m/z value of the peak apex and the m/z values left and right of it</option>
         </param>
         <param argument="integrate" type="select" label="Integration method" >

--- a/tools/xcms_macro/macros_xcms.xml
+++ b/tools/xcms_macro/macros_xcms.xml
@@ -98,7 +98,7 @@
                   <option value="maxo">maxo</option>
                   <option value="intb">intb</option>
               </param>
-              <param name="naTOzero" type="boolean" checked="true" truevalue="TRUE" falsevalue="FALSE" label="Replace the remain NA by 0 in the dataMatrix" help="Rather mandatory for some downstream statistical steps"/>
+              <param name="naTOzero" type="boolean" checked="true" truevalue="TRUE" falsevalue="FALSE" label="If NA values remain, replace them by 0 in the dataMatrix" help="Mandatory for some of the downstream tools (data processing, statistics) that do not accept NA values"/>
     </xml>
 
     <xml name="input_peaklist_section">

--- a/tools/xcms_xcmsset/abims_xcms_xcmsSet.xml
+++ b/tools/xcms_xcmsset/abims_xcms_xcmsSet.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_xcmsSet" name="xcms findChromPeaks (xcmsSet)" version="@TOOL_VERSION@+galaxy0">
+<tool id="abims_xcms_xcmsSet" name="xcms findChromPeaks (xcmsSet)" version="@TOOL_VERSION@+galaxy1">
     <description>Chromatographic peak detection</description>
 
     <macros>
@@ -502,7 +502,7 @@ Changelog/News
 
 .. _News: https://bioconductor.org/packages/release/bioc/news/xcms/NEWS
 
-**Version 3.x.x.x - 22/04/2020**
+**Version 3.6.1+galaxy1 - 22/04/2020**
 
 - NEW: possibility to get a tabular file with all the chromatographic peaks obtained with the CentWave and MatchedFilter methods. 
 

--- a/tools/xcms_xcmsset/abims_xcms_xcmsSet.xml
+++ b/tools/xcms_xcmsset/abims_xcms_xcmsSet.xml
@@ -30,6 +30,7 @@
 
         #if $methods.method == "CentWave":
             @COMMAND_CENTWAVE@
+			peaklist $methods.CentWaveAdv.peaklist
             ## List of regions-of-interest (ROI)
             #set $sectionROI = $methods.CentWaveAdv.CentWaveAdvROI
             @COMMAND_CENTWAVEADVROI@
@@ -61,6 +62,7 @@
             snthresh $methods.MatchedFilterAdv.snthresh
             steps $methods.MatchedFilterAdv.steps
             mzdiff $methods.MatchedFilterAdv.mzdiff
+			peaklist $methods.MatchedFilterAdv.peaklist
         #elif $methods.method == "MSW":
             snthresh $methods.snthresh
             verboseColumns $methods.verboseColumns
@@ -103,6 +105,7 @@
                 <expand macro="input_centwave"/>
                 <section name="CentWaveAdv" title="Advanced Options" expanded="False">
                     <expand macro="input_centwaveAdv"/>
+					<param argument="peaklist" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Get a list of found chromatographic peaks" help="Generates a tabular file with all the chromatographic peaks obtained." />
                     <section name="CentWaveAdvROI" title="List of regions-of-interest (ROI)" expanded="False">
                         <expand macro="input_centwaveAdvROI"  optional="true"/>
                     </section>
@@ -134,6 +137,7 @@
                     <param argument="snthresh" type="integer" value="10" label="Signal to Noise ratio cutoff" help="defining the signal to noise cutoff to be used in the chromatographic peak detection step" />
                     <param argument="steps" type="integer" value="2" label="Number of bins to be merged before filtration" help="(i.e. the number of neighboring bins that will be joined to the slice in which filtration and peak detection will be performed)" />
                     <param argument="mzdiff" type="float" value="0.6" label="Minimum difference in m/z for peaks with overlapping Retention Times" help="By default: 0.8-binSize*steps " />
+                    <param argument="peaklist" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Get a list of found chromatographic peaks" help="Generates a tabular file with all the chromatographic peaks obtained." />
                     <!-- index -->
                 </section>
             </when>
@@ -183,6 +187,12 @@
     <outputs>
         <data name="xsetRData" format="rdata.xcms.findchrompeaks" label="${image.name.rsplit('.',1)[0]}.xset.RData" from_work_dir="xcmsSet.RData" />
         <data name="log" format="txt" label="${image.name.rsplit('.',1)[0]}.xset.log.txt" from_work_dir="log.txt" />
+		<data name="peaklist_out1" format="tabular" label="${image.name[:-6]}.chromPeak_table.tsv" from_work_dir="chromPeak_table.tsv" >
+            <filter>methods['method'] == 'CentWave' and (methods['CentWaveAdv']['peaklist'])</filter>
+        </data>
+		<data name="peaklist_out2" format="tabular" label="${image.name[:-6]}.chromPeak_table.tsv" from_work_dir="chromPeak_table.tsv" >
+            <filter>methods['method'] == 'MatchedFilter' and (methods['MatchedFilterAdv']['peaklist'])</filter>
+        </data>
     </outputs>
 
     <tests>
@@ -491,6 +501,11 @@ Changelog/News
 --------------
 
 .. _News: https://bioconductor.org/packages/release/bioc/news/xcms/NEWS
+
+**Version 3.x.x.x - 22/04/2020**
+
+- NEW: possibility to get a tabular file with all the chromatographic peaks obtained with the CentWave and MatchedFilter methods. 
+
 
 @HELP_XCMS_NEWVERSION_3610@
 

--- a/tools/xcms_xcmsset/abims_xcms_xcmsSet.xml
+++ b/tools/xcms_xcmsset/abims_xcms_xcmsSet.xml
@@ -30,7 +30,7 @@
 
         #if $methods.method == "CentWave":
             @COMMAND_CENTWAVE@
-			peaklist $methods.CentWaveAdv.peaklist
+            peaklist $methods.CentWaveAdv.peaklist
             ## List of regions-of-interest (ROI)
             #set $sectionROI = $methods.CentWaveAdv.CentWaveAdvROI
             @COMMAND_CENTWAVEADVROI@
@@ -62,7 +62,7 @@
             snthresh $methods.MatchedFilterAdv.snthresh
             steps $methods.MatchedFilterAdv.steps
             mzdiff $methods.MatchedFilterAdv.mzdiff
-			peaklist $methods.MatchedFilterAdv.peaklist
+            peaklist $methods.MatchedFilterAdv.peaklist
         #elif $methods.method == "MSW":
             snthresh $methods.snthresh
             verboseColumns $methods.verboseColumns
@@ -105,7 +105,7 @@
                 <expand macro="input_centwave"/>
                 <section name="CentWaveAdv" title="Advanced Options" expanded="False">
                     <expand macro="input_centwaveAdv"/>
-					<param argument="peaklist" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Get a list of found chromatographic peaks" help="Generates a tabular file with all the chromatographic peaks obtained." />
+                    <param argument="peaklist" type="boolean" checked="false" truevalue="TRUE" falsevalue="FALSE" label="Get a list of found chromatographic peaks" help="Generates a tabular file with all the chromatographic peaks obtained." />
                     <section name="CentWaveAdvROI" title="List of regions-of-interest (ROI)" expanded="False">
                         <expand macro="input_centwaveAdvROI"  optional="true"/>
                     </section>
@@ -187,10 +187,10 @@
     <outputs>
         <data name="xsetRData" format="rdata.xcms.findchrompeaks" label="${image.name.rsplit('.',1)[0]}.xset.RData" from_work_dir="xcmsSet.RData" />
         <data name="log" format="txt" label="${image.name.rsplit('.',1)[0]}.xset.log.txt" from_work_dir="log.txt" />
-		<data name="peaklist_out1" format="tabular" label="${image.name[:-6]}.chromPeak_table.tsv" from_work_dir="chromPeak_table.tsv" >
+        <data name="peaklist_out1" format="tabular" label="${image.name[:-6]}.chromPeak_table.tsv" from_work_dir="chromPeak_table.tsv" >
             <filter>methods['method'] == 'CentWave' and (methods['CentWaveAdv']['peaklist'])</filter>
         </data>
-		<data name="peaklist_out2" format="tabular" label="${image.name[:-6]}.chromPeak_table.tsv" from_work_dir="chromPeak_table.tsv" >
+        <data name="peaklist_out2" format="tabular" label="${image.name[:-6]}.chromPeak_table.tsv" from_work_dir="chromPeak_table.tsv" >
             <filter>methods['method'] == 'MatchedFilter' and (methods['MatchedFilterAdv']['peaklist'])</filter>
         </data>
     </outputs>

--- a/tools/xcms_xcmsset/xcms_xcmsSet.r
+++ b/tools/xcms_xcmsset/xcms_xcmsSet.r
@@ -40,6 +40,7 @@ register(BPPARAM)
 if (!is.null(args$filterAcquisitionNum)) filterAcquisitionNumParam <- args$filterAcquisitionNum
 if (!is.null(args$filterRt)) filterRtParam <- args$filterRt
 if (!is.null(args$filterMz)) filterMzParam <- args$filterMz
+if (!is.null(args$peaklist)) peaklistParam <- args$peaklist
 
 method <- args$method
 
@@ -99,6 +100,14 @@ sampleNamesList <- getSampleMetadata(xdata=xdata, sampleMetadataOutput="sampleMe
 #cat("\t\t\tCompute and Store TIC and BPI\n")
 #chromTIC = chromatogram(xdata, aggregationFun = "sum")
 #chromBPI = chromatogram(xdata, aggregationFun = "max")
+
+# Create a chromPeaks table if required
+if (exists("peaklistParam")) {
+    if(peaklistParam){
+      cat("\nCreating the chromatographic peaks' table...\n")
+      write.table(chromPeaks(xdata), file="chromPeak_table.tsv",sep="\t",quote=F,row.names=F)
+	}
+}
 
 cat("\n\n")
 


### PR DESCRIPTION
Hi there, hi @lecorguille 

Here are some commits regarding an old issue (#111)  that is still ongoing. This should be enough to close the corresponing issue.

Please note that this issue (and thus this PR) includes a new output file (being optional) which contains the chromatographic peaks' list using the `chromPeaks()` function. By default this option is set to "No", meaning no output is generated. This concerns the 'CentWave' and 'MatchedFilter' methods since I am not confortable with the other ones (and thus do not know whether it is relevant for them or even possible). 

Any feedback is welcome! 

Mélanie

PS: I have not changed tool versions yet