### PR TITLE
[XCMS tools] Hotfix: plot for more than 9 classes

### DIFF
--- a/tools/xcms_group/abims_xcms_group.xml
+++ b/tools/xcms_group/abims_xcms_group.xml
@@ -1,4 +1,4 @@
-<tool id="abims_xcms_group" name="xcms groupChromPeaks (group)" version="@TOOL_VERSION@+galaxy1">
+<tool id="abims_xcms_group" name="xcms groupChromPeaks (group)" version="@TOOL_VERSION@+galaxy2">
 
     <description>Perform the correspondence, the grouping of chromatographic peaks within and between samples.</description>
 

--- a/tools/xcms_macro/lib.r
+++ b/tools/xcms_macro/lib.r
@@ -149,7 +149,11 @@ getPlotChromPeakDensity <- function(xdata, param = NULL, mzdigit=4) {
 
     par(mfrow = c(3, 1), mar = c(4, 4, 1, 0.5))
 
-    group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
+    if(length(unique(xdata$sample_group))<10){
+        group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
+    }else{
+        group_colors <- hcl.colors(length(unique(xdata$sample_group)), palette="Dark 3")
+    }
     names(group_colors) <- unique(xdata$sample_group)
     col_per_samp <- as.character(xdata$sample_group)
     for(i in 1:length(group_colors)){col_per_samp[col_per_samp==(names(group_colors)[i])]<-group_colors[i]}
@@ -172,7 +176,11 @@ getPlotAdjustedRtime <- function(xdata) {
     pdf(file="raw_vs_adjusted_rt.pdf", width=16, height=12)
 
     # Color by group
-    group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
+    if(length(unique(xdata$sample_group))<10){
+        group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
+    }else{
+        group_colors <- hcl.colors(length(unique(xdata$sample_group)), palette="Dark 3")
+    }
     if (length(group_colors) > 1) {
         names(group_colors) <- unique(xdata$sample_group)
         plotAdjustedRtime(xdata, col = group_colors[xdata$sample_group])
@@ -241,7 +249,11 @@ getPlotChromatogram <- function(chrom, xdata, pdfname="Chromatogram.pdf", aggreg
     pdf(pdfname, width=16, height=10)
 
     # Color by group
-    group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
+    if(length(unique(xdata$sample_group))<10){
+        group_colors <- brewer.pal(length(unique(xdata$sample_group)), "Set1")
+    }else{
+        group_colors <- hcl.colors(length(unique(xdata$sample_group)), palette="Dark 3")
+    }
     if (length(group_colors) > 1) {
         names(group_colors) <- unique(xdata$sample_group)
         plot(chrom, col = group_colors[as.factor(chrom$sample_group)], main=main, peakType = "none")

--- a/tools/xcms_plot_chromatogram/xcms_plot_chromatogram.xml
+++ b/tools/xcms_plot_chromatogram/xcms_plot_chromatogram.xml
@@ -1,4 +1,4 @@
-<tool id="xcms_plot_chromatogram" name="xcms plot chromatogram" version="@TOOL_VERSION@.0">
+<tool id="xcms_plot_chromatogram" name="xcms plot chromatogram" version="@TOOL_VERSION@+galaxy1">
     <description>Plots base peak intensity chromatogram (BPI) and total ion current chromatogram (TIC) from MSnbase or xcms experiment(s)</description>
 
     <macros>


### PR DESCRIPTION
Hi there,

One of my colaborators appeared to have more than 9 classes to process with XCMS. 
The code allowed only up to 9 classes and thus exited with an error when more classes were in line. 

I propose a fix that does not change the way colours are handled when 9 or less classes are used: it provides new colour scale only for 10 or more classes. 

I tested it on my local VM with success 😉 