### PR TITLE
Delete repository_dependencies.xml

### DIFF
--- a/tools/camera_macro/repository_dependencies.xml
+++ b/tools/camera_macro/repository_dependencies.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0"?>
-<repositories>
-	<repository name="rdata_camera_datatypes" owner="lecorguille" />
-	<repository name="rdata_xcms_datatypes" owner="lecorguille" />
-</repositories>


### PR DESCRIPTION
We would like to have this tool on the EU server, however this file is not supposed to be in the tool shed or on any servers.
Do you really need this file?

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
