### PR TITLE
Updated argument saves to correct report generation with xcms_summary tool

### DIFF
--- a/tools/camera/CAMERA_annotateDiffreport.r
+++ b/tools/camera/CAMERA_annotateDiffreport.r
@@ -35,8 +35,8 @@ cat("\n\n")
 cat("\tARGUMENTS PROCESSING INFO\n")
 
 # Save arguments to generate a report
-if (!exists("listOFargs")) listOFargs <- list()
-listOFargs[[format(Sys.time(), "%y%m%d-%H:%M:%S_annotatediff")]] <- args
+if (!exists("listOFlistArguments")) listOFlistArguments <- list()
+listOFlistArguments[[format(Sys.time(), "%y%m%d-%H:%M:%S_annotatediff")]] <- args
 
 # We unzip automatically the chromatograms from the zip files.
 if (!exists("zipfile")) zipfile <- NULL
@@ -73,7 +73,7 @@ print(xa)
 cat("\n\n")
 
 # saving R data in .Rdata file to save the variables used in the present tool
-objects2save <- c("xa", "variableMetadata", "diffrep", "cAnnot", "listOFargs", "zipfile", "singlefile")
+objects2save <- c("xa", "variableMetadata", "diffrep", "cAnnot", "listOFlistArguments", "zipfile", "singlefile")
 save(list = objects2save[objects2save %in% ls()], file = "annotatediff.RData")
 
 cat("\n\n")

--- a/tools/camera/abims_CAMERA_annotateDiffreport.xml
+++ b/tools/camera/abims_CAMERA_annotateDiffreport.xml
@@ -1,4 +1,4 @@
-<tool id="abims_CAMERA_annotateDiffreport" name="CAMERA.annotate" version="2.2.6+camera@TOOL_VERSION@-galaxy@VERSION_SUFFIX@">
+<tool id="abims_CAMERA_annotateDiffreport" name="CAMERA.annotate" version="2.2.7+camera@TOOL_VERSION@-galaxy@VERSION_SUFFIX@">
 
     <description>CAMERA annotate function. Returns annotation results (isotope peaks, adducts and fragments) and a diffreport if more than one condition.</description>
 


### PR DESCRIPTION
Hello, 
The purpose of this modification is to correct the addition of arguments between the CAMERA tools and the generation of the xcms_summary report. Previously, in the generated report, the “Function launched” section was empty. This PR corrects this problem.
Thanks a lot!

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-metabolomics/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
