### PR TITLE
xcms_plot_raw: Add mslevel filtering to the tool

### DIFF
--- a/tools/xcms/.lint_skip
+++ b/tools/xcms/.lint_skip
@@ -1,1 +1,2 @@
 version_bumped
+TestsAssertionValidation

--- a/tools/xcms/.lint_skip
+++ b/tools/xcms/.lint_skip
@@ -1,1 +1,1 @@
-ShedVersion
+version_bumped

--- a/tools/xcms/.lint_skip
+++ b/tools/xcms/.lint_skip
@@ -1,0 +1,1 @@
+ShedVersion

--- a/tools/xcms/macros_xcms_plot.xml
+++ b/tools/xcms/macros_xcms_plot.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">4.0.0</token>
+    <token name="@TOOL_VERSION@">4.4.0</token>
     <xml name="creator">
         <creator>
             <person
@@ -24,9 +24,10 @@
         </xrefs>
     </xml>
     <xml name="base_params">
-        <param type="data" name="input" format="mzML" label="Input mzML file"/>
+        <param type="data" name="input" format="mzml" label="Input mzML file"/>
         <param type="float" name="mz_value" value="10.0" min="0.0" label="m/z Value" help="m/z value for the EIC"/>
         <param type="integer" value="10" name="tolerance_ppm" min="0" label="Tolerance (ppm)" help="Tolerance for m/z value in ppm"/>
+        <param type="integer" value="1" name="mslevel" min="1" label="MS Level" help="MS level for the EIC"/>
     </xml>
     <xml name="citations">
         <citations>

--- a/tools/xcms/macros_xcms_plot.xml
+++ b/tools/xcms/macros_xcms_plot.xml
@@ -26,7 +26,7 @@
     <xml name="base_params">
         <param type="data" name="input" format="mzml" label="Input mzML file"/>
         <param type="float" name="mz_value" value="10.0" min="0.0" label="m/z Value" help="m/z value for the EIC"/>
-        <param type="integer" value="10" name="tolerance_ppm" min="0" label="Tolerance (ppm)" help="Tolerance for m/z value in ppm"/>
+        <param type="integer" value="10" name="tolerance_ppm" min="0" label="Tolerance (ppm)" help="Tolerance for m/z value in ppm. Tolerance is applied on both sides (+-)."/>
         <param type="integer" value="1" name="mslevel" min="1" label="MS Level" help="MS level for the EIC"/>
     </xml>
     <xml name="citations">

--- a/tools/xcms/xcms_plot_eic.xml
+++ b/tools/xcms/xcms_plot_eic.xml
@@ -16,6 +16,9 @@
 library(xcms)
 library(MsExperiment)
 library(Spectra)
+
+sessionInfo()
+
 mse = readMsExperiment(file.path('${input}'))
 offset = ${tolerance_ppm} * 1e-6 * ${mz_value}
 chr = chromatogram(mse, mz = ${mz_value} + c(-offset, offset), msLevel = ${mslevel})
@@ -26,7 +29,6 @@ dev.off()
     </configfiles>
     <inputs>
         <expand macro="base_params"/>
-        <param type="integer" value="1" name="mslevel" min="1" label="MS Level" help="MS level for the EIC"/>
     </inputs>
     <outputs>
         <data name="output_filename" format="png" label="EIC plot at m/z=$mz_value of $input.element_identifier"  />

--- a/tools/xcms/xcms_plot_raw.xml
+++ b/tools/xcms/xcms_plot_raw.xml
@@ -16,10 +16,15 @@
 library(xcms)
 library(MsExperiment)
 library(Spectra)
+
+sessionInfo()
+
 mse = readMsExperiment(file.path('${input}'))
 mz_offset = ${tolerance_ppm} * 1e-6 * ${mz_value}
 rt_offset = ${rt_range} / 2
+
 raw = mse |>
+    filterMsLevel(msLevel = ${mslevel}L) |>
     filterRt(rt = ${rt} + c(-rt_offset, rt_offset)) |>
     filterMzRange(mz = ${mz_value} + c(-mz_offset, mz_offset))
 png(filename = '${output_filename}')
@@ -34,7 +39,7 @@ dev.off()
         <param type="float" name="rt_range" value="5.0" min="0.0" label="Retention Time Range" help="Retention time range for the plot"/>
     </inputs>
     <outputs>
-        <data name="output_filename" format="png" label="PLot at m/z=$mz_value and rt=$rt of $input.element_identifier"/>
+        <data name="output_filename" format="png" label="Plot at m/z=$mz_value and rt=$rt of $input.element_identifier"/>
     </outputs>
     <tests>
         <test>

--- a/tools/xcms/xcms_plot_raw.xml
+++ b/tools/xcms/xcms_plot_raw.xml
@@ -21,7 +21,7 @@ sessionInfo()
 
 mse = readMsExperiment(file.path('${input}'))
 mz_offset = ${tolerance_ppm} * 1e-6 * ${mz_value}
-rt_offset = ${rt_range} / 2
+rt_offset = ${rt_range}
 
 raw = mse |>
     filterMsLevel(msLevel = ${mslevel}L) |>
@@ -36,7 +36,7 @@ dev.off()
     <inputs>
         <expand macro="base_params"/>
         <param type="float" name="rt" label="Retention Time" min="0.0" value="0.0" help="Retention time for the plot"/>
-        <param type="float" name="rt_range" value="5.0" min="0.0" label="Retention Time Range" help="Retention time range for the plot"/>
+        <param type="float" name="rt_range" value="5.0" min="0.0" label="Retention Time Range" help="Retention time range for the plot. Range is applied on both sides of the specified RT value (+-)."/>
     </inputs>
     <outputs>
         <data name="output_filename" format="png" label="Plot at m/z=$mz_value and rt=$rt of $input.element_identifier"/>
@@ -47,8 +47,13 @@ dev.off()
             <param name="mz_value" value="153.06583"/>
             <param name="tolerance_ppm" value="10"/>
             <param name="rt" value="171.922"/>
-            <param name="rt_range" value="0.1"/>
-            <output name="output_filename" file="raw_plot.png" compare="sim_size" delta="5000"/>
+            <param name="rt_range" value="5"/>
+            <output name="output_filename">
+                <assert_contents>
+                    <has_image_channels channels="3"/>
+                    <has_image_center_of_mass center_of_mass="240.30, 240.51" eps="0.1"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
This PR updates XCMS for plotting to 4.4.0 and introduces an mslevel filtering parameter. This also seems to now crash less often and work more reliably.

Fixes #299
Fixes #297
Fixes #294

I decided to instead of dividing the tolerance by 2, to rather not divide the rt range to not make it confusing.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [x] This PR updates an existing tool or tool collection

