### PR TITLE
[Intensity check] typo in tool id

### DIFF
--- a/tools/intensity_check/xml_intensity_check.xml
+++ b/tools/intensity_check/xml_intensity_check.xml
@@ -1,7 +1,7 @@
 <tool id="intens_check" name="Intensity Check" version="@TOOL_VERSION@" profile="22.05">
     <description>Statistical measures, number of missing values and mean fold change</description>
     <macros>
-        <token name="@TOOL_VERSION@">2.0.0</token>
+        <token name="@TOOL_VERSION@">2.0.1</token>
     </macros>
 
     <edam_topics>

--- a/tools/intensity_check/xml_intensity_check.xml
+++ b/tools/intensity_check/xml_intensity_check.xml
@@ -1,4 +1,4 @@
-<tool id="intensity_check" name="Intensity Check" version="@TOOL_VERSION@" profile="22.05">
+<tool id="intens_check" name="Intensity Check" version="@TOOL_VERSION@" profile="22.05">
     <description>Statistical measures, number of missing values and mean fold change</description>
     <macros>
         <token name="@TOOL_VERSION@">2.0.0</token>


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [X] License permits unrestricted use (educational + commercial)
* [ ] This PR adds a new tool or tool collection
* [X] This PR updates an existing tool or tool collection
* [ ] This PR does something else (explain below)

Once the tool has been updated on usegalaxy.fr, we noticed there was a typo in the tool id, leading to duplication in the Galaxy menus. Here is the fix.